### PR TITLE
Add length-delimited string API

### DIFF
--- a/jems.h
+++ b/jems.h
@@ -136,6 +136,12 @@ jems_t *jems_integer(jems_t *jems, int64_t value);
 jems_t *jems_string(jems_t *jems, const char *string);
 
 /**
+ * @brief Emit a string of known length in JSON format.
+ *        Useful for strings which are not null-terminated.
+ */
+jems_t *jems_string_span(jems_t *jems, const char *string, size_t len);
+
+/**
  * @brief Emit a boolean (true or false) in JSON format.
  */
 jems_t *jems_bool(jems_t *jems, bool boolean);

--- a/test/test_jems.c
+++ b/test/test_jems.c
@@ -180,6 +180,21 @@ int main(void) {
     ASSERT(test_result("\"newline \\u000a and return \\u000d oh my\""));
 
     test_reset();
+    char str_span[] = "foo bar baz";
+    jems_string_span(&s_jems, str_span, sizeof(str_span) - 1);
+    ASSERT(test_result("\"foo bar baz\""));
+
+    test_reset();
+    char str_span_with_quotes[] = "say \"foo bar baz\"!";
+    jems_string_span(&s_jems, str_span_with_quotes, sizeof(str_span_with_quotes) - 1);
+    ASSERT(test_result("\"say \\\"foo bar baz\\\"!\""));
+
+    test_reset();
+    char str_span_with_escapes[] = "newline \n and return \r oh my";
+    jems_string_span(&s_jems, str_span_with_escapes, sizeof(str_span_with_escapes) - 1);
+    ASSERT(test_result("\"newline \\u000a and return \\u000d oh my\""));
+
+    test_reset();
     ASSERT(jems_curr_level(&s_jems) == 0);
     ASSERT(jems_item_count(&s_jems) == 0);
     jems_object_open(&s_jems);


### PR DESCRIPTION
Hi! Thanks for writing this convenient little library.

I made this modification so that I could also emit data from `std::string_view`s in C++ code, which only has a pointer and length -- not guaranteed to be null-terminated.

Please let me know if there are any additional changes you'd like me to make, such as changing the `jems_string_span` name. I am notoriously bad at API naming.